### PR TITLE
Remove BackupPC 'Cache' exclude as it excludes important files

### DIFF
--- a/roles/backuppc/defaults/main.yml
+++ b/roles/backuppc/defaults/main.yml
@@ -39,7 +39,6 @@ backuppc_ping_max_msec: 20
 backuppc_files_exclude_default:
   - '.cache'
   - '.Trash*'
-  - 'Cache'
   - '/dev'
   - '/proc'
   - '/run'

--- a/roles/backuppcclient/defaults/main.yml
+++ b/roles/backuppcclient/defaults/main.yml
@@ -27,7 +27,6 @@ backuppcclient_server_known_hosts: '/container/backuppc/data/home/.ssh/known_hos
 backuppcclient_files_exclude_default:
   - '.cache'
   - '.Trash*'
-  - 'Cache'
   - '/dev'
   - '/proc'
   - '/run'


### PR DESCRIPTION
On non of our servers, the "Cache" exclude actually excludes any files that are just a cache and not already excluded by the other excludes but it did cause some files (code of a PHP CMS) to not get backed up, making the restore process not seamless. These files weren't irreplaceable but after a restore the CMS was not working correctly because of the missing files.