### PR TITLE
feat(syncoid): allow to set receive options

### DIFF
--- a/roles/syncoid/tasks/syncoid.yml
+++ b/roles/syncoid/tasks/syncoid.yml
@@ -53,6 +53,7 @@
     syncoid_dumpsnaps: "{{ syncoid_job.dumpsnaps | default(syncoid_dumpsnaps_default) }}"
     syncoid_sync_snapshot: "{{ syncoid_job.sync_snapshot | default(True) }}"
     syncoid_sendoptions: "{{ syncoid_job.sendoptions | default('Lc e w') }}"
+    syncoid_recvoptions: "{{ syncoid_job.recvoptions | default('') }}"
   include_tasks:
     file: syncoid_job.yml
     apply:

--- a/roles/syncoid/tasks/syncoid_job.yml
+++ b/roles/syncoid/tasks/syncoid_job.yml
@@ -34,6 +34,7 @@
       {% if not syncoid_source_privilege_elevation %}--no-privilege-elevation{% endif %}
       {{ ['--exclude='] | product(syncoid_exclude) | map('join') | list | join(' ') }}
       --sendoptions="{{ syncoid_sendoptions }}"
+      {% if syncoid_recvoptions != '' %}--recvoptions="{{ syncoid_recvoptions }}"{% endif %}
       --sshkey=/root/.ssh/syncoid_id_ed25519
       --sshoption StrictHostKeyChecking=accept-new
       {{ syncoid_source_host_ssh_user }}@{{ syncoid_source_host_ssh }}:{{ syncoid_source_dataset }}


### PR DESCRIPTION
This is required to receive data from an unencrypted dataset to an encrypted dataset.