### PR TITLE
update zfs_snap_metrics cron

### DIFF
--- a/roles/zfs/defaults/main.yml
+++ b/roles/zfs/defaults/main.yml
@@ -49,3 +49,5 @@ zfs_dataset_property_metrics_exclude_datasets: []
 #   - zfsdata/sync/backup4
 # zfs_dataset_property_metrics_exclude_datasets: # []
 #   - .*/archive
+
+zfs_snap_metrics_cron_interval: '*/5'

--- a/roles/zfs/tasks/main.yml
+++ b/roles/zfs/tasks/main.yml
@@ -96,7 +96,7 @@
 - name: Cronjob for zfs snap metrics
   cron:
     name: zfs_snap_metrics
-    minute: "*/5"
+    minute: "*/15"
     hour: "*"
     user: root
     job: '/usr/local/bin/zfs_snap_metrics.sh > {{ zfs_metrics_textfile_dir }}/zfs_snap_metrics.prom.new && mv {{ zfs_metrics_textfile_dir }}/zfs_snap_metrics.prom.new {{ zfs_metrics_textfile_dir }}/zfs_snap_metrics.prom'

--- a/roles/zfs/tasks/main.yml
+++ b/roles/zfs/tasks/main.yml
@@ -96,7 +96,7 @@
 - name: Cronjob for zfs snap metrics
   cron:
     name: zfs_snap_metrics
-    minute: "*/15"
+    minute: "{{ zfs_snap_metrics_cron_interval }}"
     hour: "*"
     user: root
     job: '/usr/local/bin/zfs_snap_metrics.sh > {{ zfs_metrics_textfile_dir }}/zfs_snap_metrics.prom.new && mv {{ zfs_metrics_textfile_dir }}/zfs_snap_metrics.prom.new {{ zfs_metrics_textfile_dir }}/zfs_snap_metrics.prom'


### PR DESCRIPTION
in case run of `zfs_snap_metrics.sh` is >5 mins, multiple script instances will race to lock. this can lead to corrupted `zfs_snap_metrics.prom` file.