### PR TITLE
feat(promtail): support custom binary service name

### DIFF
--- a/roles/promtail/defaults/main.yml
+++ b/roles/promtail/defaults/main.yml
@@ -146,3 +146,4 @@ promtail_additional_groups:
 
 # run promtail with user. Allows overriding to root (for debugging)
 promtail_user: promtail
+promtail_service_name: promtail

--- a/roles/promtail/handlers/main.yml
+++ b/roles/promtail/handlers/main.yml
@@ -13,11 +13,13 @@
 
 - name: restart promtail service
   service:
-    name: promtail
+    name: "{{ promtail_service_name }}"
     enabled: true
     state: restarted
   listen: restart promtail
-  when: promtail_deploy_mode == 'binary'
+  when:
+    - promtail_deploy_mode == 'binary'
+    - not ansible_check_mode
 
 - name: promtail_daemon_reload_systemd
   become: true

--- a/roles/promtail/tasks/binary.yml
+++ b/roles/promtail/tasks/binary.yml
@@ -23,7 +23,7 @@
     mode: '0750'
   with_items:
     - "{{ promtail_config_dir }}"
-    - /var/log/promtail/
+    - "{{ promtail_positions_path }}"
 
 - name: Promtail Configuration File
   template:
@@ -83,7 +83,7 @@
 - name: create systemd service unit
   template:
     src: promtail.service.j2
-    dest: /etc/systemd/system/promtail.service
+    dest: /etc/systemd/system/{{ promtail_service_name }}.service
     owner: root
     group: root
     mode: '0644'
@@ -93,5 +93,6 @@
 
 - name: Enable service promtail
   service:
-    name: promtail
+    name: "{{ promtail_service_name }}"
     enabled: true
+  when: not ansible_check_mode

--- a/roles/promtail/templates/promtail.service.j2
+++ b/roles/promtail/templates/promtail.service.j2
@@ -1,7 +1,7 @@
 # {{ ansible_managed }}
 
 [Unit]
-Description=promtail
+Description={{ promtail_service_name }}
 After=network.target
 
 [Service]
@@ -14,7 +14,7 @@ ExecStart=/usr/local/bin/promtail \
 PrivateTmp=true
 ProtectHome=true
 NoNewPrivileges=true
-SyslogIdentifier=promtail
+SyslogIdentifier={{ promtail_service_name }}
 Restart=on-failure
 RestartSec=5
 TimeoutStopSec=30


### PR DESCRIPTION
Adds support for running the binary Promtail role under a custom systemd service name.\n\n## Changes\n\n- Adds `promtail_service_name` with default `promtail`.\n- Uses `promtail_service_name` for the systemd unit path, service restart/enable, description, and syslog identifier.\n- Uses the existing `promtail_positions_path` for binary-mode positions directory creation instead of hardcoding `/var/log/promtail/`.\n- Skips binary service enable/restart during Ansible check mode to avoid failures when a new custom service does not exist yet.\n\n## Motivation\n\nNeeded for safe parallel Promtail migrations where an existing Loki shipper and a new VictoriaLogs shipper coexist temporarily under different systemd service names/config directories.\n\n## Compatibility\n\nDefault behavior is unchanged because `promtail_service_name` defaults to `promtail`.